### PR TITLE
Fix ALSA error message and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ pip install -r requirements.txt
 ### **配置**
 + 仓库已提供默认的 `system.conf` 文件，可按需修改
 
+### **依赖说明**
+Fay 需要外部语音识别（ASR）、语音合成（TTS）和大语言模型（LLM）等服务配合使用，上述地址和密钥均在 `system.conf` 中配置。例如：
+
+```ini
+ASR_mode = funasr
+local_asr_ip = 127.0.0.1
+local_asr_port = 10197
+gpt_base_url = http://127.0.0.1:5010/v1
+gpt_api_key = <your key>
+```
+
+若这些服务未启动或网络不可达，启动时可能会在终端看到 `Connection error.` 提示，请检查配置并确保相关服务正在运行。
+
+### **音频设备问题**
+在无声卡环境（如部分 Docker 容器）运行时，`pygame` 初始化音频输出可能导致 `ALSA lib` 报错。框架在代码中自动设置 `SDL_AUDIODRIVER=dummy` 以避免该问题，如仍有报错可手动在启动前设置：
+
+```bash
+export SDL_AUDIODRIVER=dummy
+```
+
 ### **启动**
 启动Fay控制器
 ```shell

--- a/core/fay_core.py
+++ b/core/fay_core.py
@@ -359,9 +359,12 @@ class FeiFei:
     #面板播放声音
     def __play_sound(self):
         try:
+            import os
+            # 当运行在无声卡环境（如Docker容器）时，使用dummy驱动避免ALSA报错
+            os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
             import pygame
             pygame.mixer.init()  # 初始化pygame.mixer，只需要在此处初始化一次, 如果初始化失败，则不播放音频
-        except Exception as e:
+        except Exception:
             util.printInfo(1, "System", "音频播放初始化失败,本机无法播放音频")
             return
         


### PR DESCRIPTION
## Summary
- handle audio initialization gracefully when no soundcard is available
- explain dependencies and connection errors in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pydub, flask, etc.)*