### PR TITLE
Improve connection error diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ gpt_base_url = http://127.0.0.1:5010/v1
 gpt_api_key = <your key>
 ```
 
-若这些服务未启动或网络不可达，启动时可能会在终端看到 `Connection error.` 提示，请检查配置并确保相关服务正在运行。
+若这些服务未启动或网络不可达，启动或交互时可能会在终端看到 `Connection error.` 提示。
+请检查 `system.conf` 中 `gpt_base_url` 等设置是否正确，并确保 ASR、TTS 和语言模型服务均已启动并可访问。
 
 ### **音频设备问题**
 在无声卡环境（如部分 Docker 容器）运行时，`pygame` 初始化音频输出可能导致 `ALSA lib` 报错。框架在代码中自动设置 `SDL_AUDIODRIVER=dummy` 以避免该问题，如仍有报错可手动在启动前设置：

--- a/llm/nlp_cognitive_stream.py
+++ b/llm/nlp_cognitive_stream.py
@@ -474,6 +474,8 @@ def question(content, username, observation=None):
 
         except requests.exceptions.RequestException as e:
             util.log(1, f"请求失败: {e}")
+            if isinstance(e, requests.exceptions.ConnectionError):
+                util.log(1, "无法连接到语言模型服务，请检查 system.conf 中 gpt_base_url 是否正确并确保该服务已启动")
             error_message = "抱歉，我现在太忙了，休息一会，请稍后再试。"
             stream_manager.new_instance().write_sentence(username, "_<isfirst>" + error_message + "_<isend>")
             full_response_text = error_message


### PR DESCRIPTION
## Summary
- expand README with troubleshooting steps for `Connection error.` messages
- log clearer hint when failing to connect to the LLM service

## Testing
- `python -m py_compile llm/nlp_cognitive_stream.py`